### PR TITLE
fix: 修复异常抛出的语法错误问题

### DIFF
--- a/src/Sts.php
+++ b/src/Sts.php
@@ -14,7 +14,7 @@ class Sts{
 		ksort($obj);
 		$arr = array();
 		if(!is_array($obj)){
-			throw new \Exception($obj + " must be a array");
+			throw new \Exception('$obj must be an array, the actual value is:' . json_encode($obj));
 		}
 		foreach ($obj as $key => $val) {
 			array_push($arr, $key . '=' . ($notEncode ? $val : rawurlencode($val)));
@@ -31,7 +31,7 @@ class Sts{
 	// v2接口的key首字母小写，v3改成大写，此处做了向下兼容
 	function backwardCompat($result) {
 		if(!is_array($result)){
-			throw new \Exception($result + " must be a array");
+			throw new \Exception('$result must be an array, the actual value is:' . json_encode($result));
 		}
 		$compat = array();
 		foreach ($result as $key => $value) {


### PR DESCRIPTION
首先，在 `php` 中，字符串连接用 `.` 而不是 `+`，请不要与 `javascript` 混淆
其次，对于不明类型的变量 `$obj`，`$result`，不建议直接与字符串连接，通过编码函数 `json_encode` 或 `serialize` 序列化为字符串后再连接
请尽快处理，否则在网络异常时，php接口将输出敏感错误信息且无法通过 `try ... catch ...` 捕获